### PR TITLE
Add deployment workflow

### DIFF
--- a/.github/workflows/cd_onto-ns.yml
+++ b/.github/workflows/cd_onto-ns.yml
@@ -1,17 +1,15 @@
 name: CD - Deploy to onto-ns.com
 
 on:
-  # workflow_run:
-  #   workflows: ["CI - Tests"]
-  #   types: [completed]
-  #   branches: [main]
-  push:
-    branches: [cwa/close-6-cd]
+  workflow_run:
+    workflows: ["CI - Tests"]
+    types: [completed]
+    branches: [main]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Set up Python 3.10
@@ -59,7 +57,7 @@ jobs:
               )
           print(
               "SUCCESS!\n"
-              f"  code: {response['service']}\n"
+              f"  code: {response['returncode']}\n"
               f"  stdout:\n{response['stdout']}"
           )
 

--- a/.github/workflows/cd_onto-ns.yml
+++ b/.github/workflows/cd_onto-ns.yml
@@ -1,15 +1,17 @@
 name: CD - Deploy to onto-ns.com
 
 on:
-  workflow_run:
-    workflows: ["CI - Tests"]
-    types: [completed]
-    branches: [main]
+  # workflow_run:
+  #   workflows: ["CI - Tests"]
+  #   types: [completed]
+  #   branches: [main]
+  push:
+    branches: [cwa/close-6-cd]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Set up Python 3.10

--- a/.github/workflows/cd_onto-ns.yml
+++ b/.github/workflows/cd_onto-ns.yml
@@ -1,0 +1,64 @@
+name: CD - Deploy to onto-ns.com
+
+on:
+  workflow_run:
+    workflows: ["CI - Tests"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y curl
+
+          python -m pip install --upgrade pip
+          pip install -U setuptools wheel
+          pip install -U requests
+
+      - name: Deploy updated main
+        run: |
+          curl -o response.json --silent -m 30 http://api.onto-ns.com/dlite/?service=dlite-entities-service
+
+          cat << EOF | python
+          import json
+          from pathlib import Path
+          import sys
+
+          response = json.loads(Path('response.json').read_bytes())
+          if response["service"] != "dlite-entities-service":
+              sys.exit(
+                  "ERROR: Did not deploy the correct service\n"
+                  f"  service: {response['service']}\n"
+                  f"  code: {response['returncode']}\n"
+                  f"  stderr: {response['stderr']}\n\n"
+                  f"  stdout: {response['stdout']}"
+              )
+          if response["returncode"] != 0:
+              sys.exit(
+                  "ERROR: Non-zero return code\n"
+                  f"  code: {response['returncode']}\n"
+                  f"  stderr:\n{response['stderr']}\n\n"
+                  f"  stdout:\n{response['stdout']}"
+              )
+          if response["stderr"]:
+              print(
+                  "WARNING: stderr is not empty\n"
+                  f"  stderr:\n{response['stderr']}\n\n"
+              )
+          print(
+              "SUCCESS!\n"
+              f"  code: {response['service']}\n"
+              f"  stdout:\n{response['stdout']}"
+          )
+
+          EOF


### PR DESCRIPTION
Closes #6

Add a continuous deployment script, utilizing the Deploy on onto-ns.com (dlite) service running at http://api.onto-ns.com/dlite (check out [ReDoc](http://api.onto-ns.com/dlite/redoc) or [Swagger UI](http://api.onto-ns.com/dlite/docs)).

This script should only run after the [CI - Tests](https://github.com/SINTEF/dlite-entities-service/blob/main/.github/workflows/ci_tests.yml) workflow _succeeds_ and was run due to a push to the `main` branch.