### PR TITLE
Use custom MongoDsn pydantic URL type

### DIFF
--- a/dlite_entities_service/config.py
+++ b/dlite_entities_service/config.py
@@ -2,8 +2,14 @@
 from typing import Any
 
 from pydantic import Field, SecretStr, field_validator
-from pydantic.networks import AnyHttpUrl, MongoDsn
+from pydantic.networks import AnyHttpUrl, MultiHostUrl, UrlConstraints
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing_extensions import Annotated
+
+MongoSrvDsn = Annotated[
+    MultiHostUrl, UrlConstraints(allowed_schemes=["mongodb", "mongodb+srv"])
+]
+"""Support MongoDB schemes with hidden port (no default port)."""
 
 
 class ServiceSettings(BaseSettings):
@@ -13,8 +19,8 @@ class ServiceSettings(BaseSettings):
         AnyHttpUrl("http://onto-ns.com/meta"),
         description="Base URL, where the service is running.",
     )
-    mongo_uri: MongoDsn = Field(
-        MongoDsn("mongodb://localhost:27017"),
+    mongo_uri: MongoSrvDsn = Field(
+        MongoSrvDsn("mongodb://localhost:27017"),
         description="URI for the MongoDB cluster/server.",
     )
     mongo_user: str | None = Field(


### PR DESCRIPTION
Need a type that doesn't include a default port, to avoid this default port being added to the represented URL when not desired.

Fixes #31 