### PR TITLE
Split pydantic models to include SOFT5 as well

### DIFF
--- a/.github/utils/docker_test.py
+++ b/.github/utils/docker_test.py
@@ -13,10 +13,10 @@ from dlite import Instance
 from pymongo import MongoClient
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Any, Literal
 
 
-DLITE_TEST_ENTITIES = [
+DLITE_TEST_ENTITIES: "list[dict[str, Any]]" = [
     {
         "uri": "http://onto-ns.com/meta/0.1/Person",
         "meta": "http://onto-ns.com/meta/0.3/EntitySchema",
@@ -63,6 +63,42 @@ DLITE_TEST_ENTITIES = [
             },
         },
     },
+    # SOFT5 example
+    {
+        "name": "Dog",
+        "version": "0.1",
+        "namespace": "http://onto-ns.com/meta",
+        "description": "A dog.",
+        "dimensions": [
+            {
+                "name": "ncolors",
+                "description": "Number of different colors the dog has.",
+            }
+        ],
+        "properties": [
+            {
+                "name": "name",
+                "type": "string",
+                "description": "The dog's name.",
+            },
+            {
+                "name": "age",
+                "type": "int",
+                "description": "The dog's age.",
+            },
+            {
+                "name": "color",
+                "type": "string",
+                "description": "The dog's different colors.",
+                "dims": ["ncolors"],
+            },
+            {
+                "name": "breed",
+                "type": "string",
+                "description": "The dog's breed.",
+            },
+        ],
+    },
 ]
 
 
@@ -79,9 +115,7 @@ def add_testdata() -> None:
 
     client = MongoClient(mongodb_uri, username=mongodb_user, password=mongodb_pass)
     collection = client.dlite.entities
-
-    for test_entity in DLITE_TEST_ENTITIES:
-        collection.insert_one(test_entity)
+    collection.insert_many(DLITE_TEST_ENTITIES)
 
 
 def _get_version_name(uri: str) -> tuple[str, str]:

--- a/.github/utils/docker_test.py
+++ b/.github/utils/docker_test.py
@@ -145,7 +145,9 @@ def run_tests() -> None:
     host = os.getenv("DOCKER_TEST_HOST", "localhost")
     port = os.getenv("DOCKER_TEST_PORT", "8000")
     for test_entity in DLITE_TEST_ENTITIES:
-        uri = test_entity.get("uri", _get_uri(test_entity))
+        uri = test_entity.get("uri")
+        if uri is None:
+            uri = _get_uri(test_entity)
         if not isinstance(uri, str):
             raise TypeError("uri must be a string")
         version, name = _get_version_name(uri)

--- a/dlite_entities_service/main.py
+++ b/dlite_entities_service/main.py
@@ -8,7 +8,7 @@ from dlite_entities_service import __version__
 from dlite_entities_service.backend import ENTITIES_COLLECTION
 from dlite_entities_service.config import CONFIG
 from dlite_entities_service.logger import LOGGER
-from dlite_entities_service.models import Entity
+from dlite_entities_service.models import VersionedSOFTEntity
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any
@@ -37,7 +37,7 @@ The changed bits pertain to `minor` and `patch`, which are now both optional.
 
 @APP.get(
     "/{version}/{name}",
-    response_model=Entity,
+    response_model=VersionedSOFTEntity,
     response_model_by_alias=True,
     response_model_exclude_unset=True,
 )
@@ -56,7 +56,7 @@ async def get_entity(
     """Get a DLite entity."""
     query = {
         "$or": [
-            {"version": version, "name": name},
+            {"namespace": CONFIG.base_url, "version": version, "name": name},
             {"uri": f"{CONFIG.base_url}/{version}/{name}"},
         ]
     }

--- a/dlite_entities_service/main.py
+++ b/dlite_entities_service/main.py
@@ -56,7 +56,7 @@ async def get_entity(
     """Get a DLite entity."""
     query = {
         "$or": [
-            {"namespace": CONFIG.base_url, "version": version, "name": name},
+            {"namespace": str(CONFIG.base_url), "version": version, "name": name},
             {"uri": f"{CONFIG.base_url}/{version}/{name}"},
         ]
     }

--- a/dlite_entities_service/models/__init__.py
+++ b/dlite_entities_service/models/__init__.py
@@ -1,0 +1,25 @@
+"""SOFT models."""
+from pydantic import ValidationError
+
+from .soft5 import SOFT5Entity
+from .soft7 import SOFT7Entity
+
+VersionedSOFTEntity = SOFT5Entity | SOFT7Entity
+
+
+def soft_entity(*args, **kwargs) -> VersionedSOFTEntity:
+    """Return the correct version of the SOFT Entity."""
+    errors = []
+    for versioned_entity_cls in (SOFT7Entity, SOFT5Entity):
+        try:
+            new_object = versioned_entity_cls(*args, **kwargs)
+            break
+        except ValidationError as exc:
+            errors.append(exc)
+            continue
+    else:
+        raise ValueError(
+            "Cannot instantiate entity. Errors:\n"
+            + "\n".join(str(error) for error in errors)
+        )
+    return new_object  # type: ignore[return-value]

--- a/dlite_entities_service/models/soft5.py
+++ b/dlite_entities_service/models/soft5.py
@@ -1,0 +1,121 @@
+"""SOFT5 models."""
+# pylint: disable=duplicate-code
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic.networks import AnyHttpUrl
+
+from dlite_entities_service.config import CONFIG
+
+
+class SOFT5Dimension(BaseModel):
+    """The defining metadata for a SOFT5 Entity's dimension."""
+
+    name: str = Field(..., description="The name of the dimension.")
+    description: str = Field(
+        ..., description="A human-readable description of the dimension."
+    )
+
+
+class SOFT5Property(BaseModel):
+    """The defining metadata for a SOFT5 Entity's property."""
+
+    name: str | None = Field(
+        None,
+        description=("The name of the property."),
+    )
+    type_: str = Field(
+        ...,
+        alias="type",
+        description="The type of the described property, e.g., an integer.",
+    )
+    ref: AnyHttpUrl | None = Field(
+        None,
+        alias="$ref",
+        definition=(
+            "Formally a part of type. `$ref` is used together with the `ref` type, "
+            "which is a special datatype for referring to other instances."
+        ),
+    )
+    dims: list[str] | None = Field(
+        None,
+        description=(
+            "The dimension of multi-dimensional properties. This is a list of "
+            "dimension expressions referring to the dimensions defined above. For "
+            "instance, if an entity have dimensions with names `H`, `K`, and `L` and "
+            "a property with shape `['K', 'H+1']`, the property of an instance of "
+            "this entity with dimension values `H=2`, `K=2`, `L=6` will have shape "
+            "`[2, 3]`."
+        ),
+    )
+    unit: str | None = Field(None, description="The unit of the property.")
+    description: str = Field(
+        ..., description="A human-readable description of the property."
+    )
+
+
+class SOFT5Entity(BaseModel):
+    """A SOFT5 Entity returned from this service."""
+
+    name: str | None = Field(None, description="The name of the entity.")
+    version: str | None = Field(None, description="The version of the entity.")
+    namespace: AnyHttpUrl | None = Field(
+        None, description="The namespace of the entity."
+    )
+    uri: AnyHttpUrl | None = Field(
+        None,
+        description=(
+            "The universal identifier for the entity. This MUST start with the base "
+            "URL."
+        ),
+    )
+    meta: AnyHttpUrl = Field(
+        AnyHttpUrl("http://onto-ns.com/meta/0.3/EntitySchema"),
+        description=(
+            "URI for the metadata entity. For all entities at onto-ns.com, the "
+            "EntitySchema v0.3 is used."
+        ),
+    )
+    description: str = Field("", description="Description of the entity.")
+    dimensions: list[SOFT5Dimension] = Field(
+        [],
+        description="A list of dimensions with name and an accompanying description.",
+    )
+    properties: list[SOFT5Property] = Field(..., description="A list of properties.")
+
+    @field_validator("uri", "namespace")
+    @classmethod
+    def _validate_base_url(cls, value: AnyHttpUrl) -> AnyHttpUrl:
+        """Validate `uri` starts with the current base URL for the service."""
+        if not str(value).startswith(str(CONFIG.base_url)):
+            raise ValueError(
+                "This service only works with DLite/SOFT entities at "
+                f"{CONFIG.base_url}."
+            )
+        return value
+
+    @field_validator("meta")
+    @classmethod
+    def _only_support_onto_ns(cls, value: AnyHttpUrl) -> AnyHttpUrl:
+        """Validate `meta` only refers to onto-ns.com EntitySchema v0.3."""
+        if str(value) != "http://onto-ns.com/meta/0.3/EntitySchema":
+            raise ValueError(
+                "This service only works with DLite/SOFT entities using EntitySchema "
+                "v0.3 at onto-ns.com as the metadata entity."
+            )
+        return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_cross_dependent_fields(cls, data: Any) -> Any:
+        """Check that `name`, `version`, and `namespace` are all set or all unset."""
+        if isinstance(data, dict):
+            if any(data.get(_) is None for _ in ("name", "version", "namespace")):
+                if not all(
+                    data.get(_) is None for _ in ("name", "version", "namespace")
+                ):
+                    raise ValueError(
+                        "Either all of `name`, `version`, and `namespace` must be set "
+                        "or all must be unset."
+                    )
+        return data

--- a/dlite_entities_service/models/soft7.py
+++ b/dlite_entities_service/models/soft7.py
@@ -1,14 +1,15 @@
-"""Pydantic models."""
-from typing import Literal
+"""SOFT7 models."""
+# pylint: disable=duplicate-code
+from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic.networks import AnyHttpUrl
 
 from dlite_entities_service.config import CONFIG
 
 
-class DLiteProperty(BaseModel):
-    """The defining metadata for a DLite Entity's property."""
+class SOFT7Property(BaseModel):
+    """The defining metadata for a SOFT7 Entity's property."""
 
     name: str | None = Field(
         None,
@@ -38,7 +39,7 @@ class DLiteProperty(BaseModel):
             "instance, if an entity have dimensions with names `H`, `K`, and `L` and "
             "a property with shape `['K', 'H+1']`, the property of an instance of "
             "this entity with dimension values `H=2`, `K=2`, `L=6` will have shape "
-            "`[2, 3]`."
+            "`[2, 3]`. Note, this was called `dims` in SOFT5."
         ),
     )
     unit: str | None = Field(None, description="The unit of the property.")
@@ -47,9 +48,14 @@ class DLiteProperty(BaseModel):
     )
 
 
-class Entity(BaseModel):
-    """A DLite Entity returned from this service."""
+class SOFT7Entity(BaseModel):
+    """A SOFT7 Entity returned from this service."""
 
+    name: str | None = Field(None, description="The name of the entity.")
+    version: str | None = Field(None, description="The version of the entity.")
+    namespace: AnyHttpUrl | None = Field(
+        None, description="The namespace of the entity."
+    )
     uri: AnyHttpUrl = Field(
         ...,
         description=(
@@ -57,8 +63,8 @@ class Entity(BaseModel):
             "URL."
         ),
     )
-    meta: Literal["http://onto-ns.com/meta/0.3/EntitySchema"] = Field(
-        ...,
+    meta: AnyHttpUrl = Field(
+        AnyHttpUrl("http://onto-ns.com/meta/0.3/EntitySchema"),
         description=(
             "URI for the metadata entity. For all entities at onto-ns.com, the "
             "EntitySchema v0.3 is used."
@@ -68,7 +74,7 @@ class Entity(BaseModel):
     dimensions: dict[str, str] = Field(
         {}, description="A dict of dimensions with an accompanying description."
     )
-    properties: dict[str, DLiteProperty] = Field(
+    properties: dict[str, SOFT7Property] = Field(
         ...,
         description=(
             "A dictionary of properties, mapping the property name to a dictionary of "
@@ -76,12 +82,39 @@ class Entity(BaseModel):
         ),
     )
 
-    @field_validator("uri")
+    @field_validator("uri", "namespace")
     @classmethod
     def _validate_base_url(cls, value: AnyHttpUrl) -> AnyHttpUrl:
         """Validate `uri` starts with the current base URL for the service."""
         if not str(value).startswith(str(CONFIG.base_url)):
             raise ValueError(
-                f"This service only works with DLite entities at {CONFIG.base_url}."
+                "This service only works with DLite/SOFT entities at "
+                f"{CONFIG.base_url}."
             )
         return value
+
+    @field_validator("meta")
+    @classmethod
+    def _only_support_onto_ns(cls, value: AnyHttpUrl) -> AnyHttpUrl:
+        """Validate `meta` only refers to onto-ns.com EntitySchema v0.3."""
+        if str(value) != "http://onto-ns.com/meta/0.3/EntitySchema":
+            raise ValueError(
+                "This service only works with DLite/SOFT entities using EntitySchema "
+                "v0.3 at onto-ns.com as the metadata entity."
+            )
+        return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_cross_dependent_fields(cls, data: Any) -> Any:
+        """Check that `name`, `version`, and `namespace` are all set or all unset."""
+        if isinstance(data, dict):
+            if any(data.get(_) is None for _ in ("name", "version", "namespace")):
+                if not all(
+                    data.get(_) is None for _ in ("name", "version", "namespace")
+                ):
+                    raise ValueError(
+                        "Either all of `name`, `version`, and `namespace` must be set "
+                        "or all must be unset."
+                    )
+        return data


### PR DESCRIPTION
This PR splits the basic pydantic Entity model class into SOFT5 and SOFT7 model classes.

In addition to the split, the SOFT7 (original model class) is extended to include uri sub parts (namespace, version, and name).

Closes #38 