### PR TITLE
Separate out entity models in SOFT and DLite

### DIFF
--- a/dlite_entities_service/main.py
+++ b/dlite_entities_service/main.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Annotated
 from fastapi import FastAPI, HTTPException, Path, status
 
 from dlite_entities_service import __version__
-from dlite_entities_service.models import VersionedSOFTEntity
+from dlite_entities_service.models import Entity
 from dlite_entities_service.service.backend import ENTITIES_COLLECTION
 from dlite_entities_service.service.config import CONFIG
 from dlite_entities_service.service.logger import setup_logger
@@ -61,7 +61,7 @@ The changed bits pertain to `minor` and `patch`, which are now both optional.
 
 @APP.get(
     "/{version}/{name}",
-    response_model=VersionedSOFTEntity,
+    response_model=Entity,
     response_model_by_alias=True,
     response_model_exclude_unset=True,
 )

--- a/dlite_entities_service/models/__init__.py
+++ b/dlite_entities_service/models/__init__.py
@@ -5,18 +5,20 @@ from typing import get_args
 
 from pydantic import ValidationError
 
-from .soft5 import URI_REGEX, SOFT5Entity
+from .dlite import DLiteEntity
+from .soft import URI_REGEX
+from .soft5 import SOFT5Entity
 from .soft7 import SOFT7Entity
 
-VersionedSOFTEntity = SOFT7Entity | SOFT5Entity
+Entity = SOFT7Entity | SOFT5Entity | DLiteEntity
 
 
 def soft_entity(
     *, return_errors: bool = False, **fields
-) -> VersionedSOFTEntity | list[ValidationError]:
-    """Return the correct version of the SOFT Entity."""
+) -> Entity | list[ValidationError]:
+    """Return the correct version of the Entity."""
     errors = []
-    for versioned_entity_cls in get_args(VersionedSOFTEntity):
+    for versioned_entity_cls in get_args(Entity):
         try:
             new_object = versioned_entity_cls(**fields)
             break
@@ -34,7 +36,7 @@ def soft_entity(
     return new_object  # type: ignore[return-value]
 
 
-def get_uri(entity: VersionedSOFTEntity) -> str:
+def get_uri(entity: Entity) -> str:
     """Return the URI of the entity."""
     if entity.uri is not None:
         return str(entity.uri)
@@ -42,7 +44,7 @@ def get_uri(entity: VersionedSOFTEntity) -> str:
     return f"{entity.namespace}/{entity.version}/{entity.name}"
 
 
-def get_version(entity: VersionedSOFTEntity) -> str:
+def get_version(entity: Entity) -> str:
     """Return the version of the entity."""
     if entity.version is not None:
         return entity.version
@@ -53,7 +55,7 @@ def get_version(entity: VersionedSOFTEntity) -> str:
     raise ValueError("Cannot parse URI to get version.")
 
 
-def get_updated_version(entity: VersionedSOFTEntity) -> str:
+def get_updated_version(entity: Entity) -> str:
     """Return the updated version of the entity."""
     current_version = get_version(entity)
 

--- a/dlite_entities_service/models/dlite.py
+++ b/dlite_entities_service/models/dlite.py
@@ -1,0 +1,111 @@
+"""DLite model."""
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import AliasChoices, Field, field_validator
+from pydantic.networks import AnyHttpUrl
+
+from dlite_entities_service.models.soft5 import SOFT5Entity, SOFT5Property
+from dlite_entities_service.models.soft7 import SOFT7Entity, SOFT7Property
+
+
+class DLiteSOFT5Property(SOFT5Property):
+    """The defining metadata for a (SOFT5-based) DLite Entity's property."""
+
+    ref: Annotated[
+        AnyHttpUrl | None,
+        Field(
+            validation_alias=AliasChoices("$ref", "ref"),
+            serialization_alias="$ref",
+            description=(
+                "Formally a part of type. `$ref` is used together with the `ref` type, "
+                "which is a special datatype for referring to other instances."
+            ),
+        ),
+    ] = None
+
+
+class DLiteSOFT5Entity(SOFT5Entity):
+    """A (SOFT5-based) DLite Entity."""
+
+    meta: Annotated[
+        AnyHttpUrl,
+        Field(
+            description=(
+                "URI for the metadata entity. For all entities at onto-ns.com, the "
+                "EntitySchema v0.3 is used."
+            ),
+        ),
+    ] = AnyHttpUrl("http://onto-ns.com/meta/0.3/EntitySchema")
+
+    properties: Annotated[  # type: ignore[assignment]
+        list[DLiteSOFT5Property], Field(description="A list of properties.")
+    ]
+
+    @field_validator("meta", mode="after")
+    @classmethod
+    def _only_support_onto_ns(cls, value: AnyHttpUrl) -> AnyHttpUrl:
+        """Validate `meta` only refers to onto-ns.com EntitySchema v0.3."""
+        if str(value).rstrip("/") != "http://onto-ns.com/meta/0.3/EntitySchema":
+            error_message = (
+                "This service only works with DLite entities using EntitySchema "
+                "v0.3 at onto-ns.com as the metadata entity.\n"
+            )
+            raise ValueError(error_message)
+        return value
+
+
+class DLiteSOFT7Property(SOFT7Property):
+    """The defining metadata for a (SOFT7-based) DLite Entity's property."""
+
+    ref: Annotated[
+        AnyHttpUrl | None,
+        Field(
+            validation_alias=AliasChoices("$ref", "ref"),
+            serialization_alias="$ref",
+            description=(
+                "Formally a part of type. `$ref` is used together with the `ref` type, "
+                "which is a special datatype for referring to other instances."
+            ),
+        ),
+    ] = None
+
+
+class DLiteSOFT7Entity(SOFT7Entity):
+    """A (SOFT7-based) DLite Entity."""
+
+    meta: Annotated[
+        AnyHttpUrl,
+        Field(
+            description=(
+                "URI for the metadata entity. For all entities at onto-ns.com, the "
+                "EntitySchema v0.3 is used."
+            ),
+        ),
+    ] = AnyHttpUrl("http://onto-ns.com/meta/0.3/EntitySchema")
+
+    properties: Annotated[  # type: ignore[assignment]
+        dict[str, DLiteSOFT7Property],
+        Field(
+            description=(
+                "A dictionary of properties, mapping the property name to a dictionary "
+                "of metadata defining the property."
+            ),
+        ),
+    ]
+
+    @field_validator("meta", mode="after")
+    @classmethod
+    def _only_support_onto_ns(cls, value: AnyHttpUrl) -> AnyHttpUrl:
+        """Validate `meta` only refers to onto-ns.com EntitySchema v0.3."""
+        if str(value).rstrip("/") != "http://onto-ns.com/meta/0.3/EntitySchema":
+            error_message = (
+                "This service only works with DLite entities using EntitySchema "
+                "v0.3 at onto-ns.com as the metadata entity.\n"
+            )
+            raise ValueError(error_message)
+        return value
+
+
+DLiteEntity = DLiteSOFT7Entity | DLiteSOFT5Entity

--- a/dlite_entities_service/models/soft.py
+++ b/dlite_entities_service/models/soft.py
@@ -1,0 +1,148 @@
+"""Base (minimum set) models for SOFT entities."""
+from __future__ import annotations
+
+import difflib
+import re
+from typing import Annotated, Any
+
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+from pydantic.networks import AnyHttpUrl
+
+from dlite_entities_service.service.config import CONFIG
+
+URI_REGEX = re.compile(
+    r"^(?P<namespace>https?://.+)/(?P<version>\d(?:\.\d+){0,2})/(?P<name>[^/#?]+)$"
+)
+"""Regular expression to parse a SOFT entity URI."""
+
+
+class SOFTProperty(BaseModel):
+    """The minimum set of defining metadata for a SOFT Entity's property."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type_: Annotated[
+        str,
+        Field(
+            alias="type",
+            description="The type of the described property, e.g., an integer.",
+        ),
+    ]
+    shape: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "The dimension of multi-dimensional properties. This is a list of "
+                "dimension expressions referring to the dimensions defined above. For "
+                "instance, if an entity have dimensions with names `H`, `K`, and `L` "
+                "and a property with shape `['K', 'H+1']`, the property of an instance "
+                "of this entity with dimension values `H=2`, `K=2`, `L=6` will have "
+                "shape `[2, 3]`."
+            ),
+            validation_alias=AliasChoices("dims", "shape"),
+        ),
+    ] = None
+    unit: Annotated[str | None, Field(description="The unit of the property.")] = None
+    description: Annotated[
+        str, Field(description="A human-readable description of the property.")
+    ]
+
+
+class SOFTEntity(BaseModel):
+    """A minimum Field set SOFT Entity to be used in a versioned SOFT Entity model."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Annotated[str | None, Field(description="The name of the entity.")] = None
+    version: Annotated[
+        str | None, Field(description="The version of the entity.")
+    ] = None
+    namespace: Annotated[
+        AnyHttpUrl | None, Field(description="The namespace of the entity.")
+    ] = None
+    uri: Annotated[
+        AnyHttpUrl | None,
+        Field(
+            description=(
+                "The universal identifier for the entity. This MUST start with the base"
+                " URL."
+            ),
+        ),
+    ] = None
+    description: Annotated[str, Field(description="Description of the entity.")] = ""
+
+    @field_validator("uri", "namespace", mode="after")
+    @classmethod
+    def _validate_base_url(cls, value: AnyHttpUrl) -> AnyHttpUrl:
+        """Validate `uri` and `namespace` starts with the current base URL for the
+        service."""
+        if not str(value).startswith(str(CONFIG.base_url)):
+            error_message = (
+                "This service only works with SOFT entities at " f"{CONFIG.base_url}.\n"
+            )
+            raise ValueError(error_message)
+        return value
+
+    @field_validator("uri", mode="after")
+    @classmethod
+    def _validate_uri(cls, value: AnyHttpUrl) -> AnyHttpUrl:
+        """Validate `uri` is consistent with `name`, `version`, and `namespace`."""
+        if URI_REGEX.match(str(value)) is None:
+            error_message = (
+                "The 'uri' is not a valid SOFT7 entity URI. It must be of the form "
+                f"{str(CONFIG.base_url).rstrip('/')}/{{version}}/{{name}}.\n"
+            )
+            raise ValueError(error_message)
+        return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_cross_dependent_fields(cls, data: Any) -> Any:
+        """Check that `name`, `version`, and `namespace` are all set or all unset."""
+        if (
+            isinstance(data, dict)
+            and any(data.get(_) is None for _ in ("name", "version", "namespace"))
+            and not all(data.get(_) is None for _ in ("name", "version", "namespace"))
+        ):
+            error_message = (
+                "Either all of `name`, `version`, and `namespace` must be set "
+                "or all must be unset.\n"
+            )
+            raise ValueError(error_message)
+
+        if (
+            isinstance(data, dict)
+            and any(data.get(_) is None for _ in ("name", "version", "namespace"))
+            and data.get("uri") is None
+        ):
+            error_message = (
+                "Either `name`, `version`, and `namespace` or `uri` must be set.\n"
+            )
+            raise ValueError(error_message)
+
+        if (
+            isinstance(data, dict)
+            and all(data.get(_) is not None for _ in ("name", "version", "namespace"))
+            and data.get("uri") is not None
+            and data["uri"] != f"{data['namespace']}/{data['version']}/{data['name']}"
+        ):
+            # Ensure that `uri` is consistent with `name`, `version`, and `namespace`.
+            diff = "\n  ".join(
+                difflib.ndiff(
+                    [data["uri"]],
+                    [f"{data['namespace']}/{data['version']}/{data['name']}"],
+                )
+            )
+            error_message = (
+                "The `uri` is not consistent with `name`, `version`, and "
+                f"`namespace`:\n\n  {diff}\n\n"
+            )
+            raise ValueError(error_message)
+        return data

--- a/dlite_entities_service/models/soft5.py
+++ b/dlite_entities_service/models/soft5.py
@@ -1,19 +1,11 @@
-"""SOFT5 models."""
+"""SOFT5 model."""
 from __future__ import annotations
 
-import difflib
-import re
-from typing import Annotated, Any
+from typing import Annotated
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
-from pydantic.networks import AnyHttpUrl
+from pydantic import BaseModel, Field
 
-from dlite_entities_service.service.config import CONFIG
-
-URI_REGEX = re.compile(
-    r"^(?P<namespace>https?://.+)/(?P<version>\d(?:\.\d+){0,2})/(?P<name>[^/#?]+)$"
-)
-"""Regular expression to parse a SOFT entity URI."""
+from dlite_entities_service.models.soft import SOFTEntity, SOFTProperty
 
 
 class SOFT5Dimension(BaseModel):
@@ -25,81 +17,15 @@ class SOFT5Dimension(BaseModel):
     ]
 
 
-class SOFT5Property(BaseModel):
+class SOFT5Property(SOFTProperty):
     """The defining metadata for a SOFT5 Entity's property."""
 
-    name: Annotated[
-        str | None,
-        Field(
-            description=("The name of the property."),
-        ),
-    ] = None
-    type_: Annotated[
-        str,
-        Field(
-            alias="type",
-            description="The type of the described property, e.g., an integer.",
-        ),
-    ]
-    ref: Annotated[
-        AnyHttpUrl | None,
-        Field(
-            validation_alias=AliasChoices("$ref", "ref"),
-            serialization_alias="$ref",
-            description=(
-                "Formally a part of type. `$ref` is used together with the `ref` type, "
-                "which is a special datatype for referring to other instances."
-            ),
-        ),
-    ] = None
-    dims: Annotated[
-        list[str] | None,
-        Field(
-            description=(
-                "The dimension of multi-dimensional properties. This is a list of "
-                "dimension expressions referring to the dimensions defined above. For "
-                "instance, if an entity have dimensions with names `H`, `K`, and `L` "
-                "and a property with shape `['K', 'H+1']`, the property of an instance "
-                "of this entity with dimension values `H=2`, `K=2`, `L=6` will have "
-                "shape `[2, 3]`."
-            ),
-        ),
-    ] = None
-    unit: Annotated[str | None, Field(description="The unit of the property.")] = None
-    description: Annotated[
-        str, Field(description="A human-readable description of the property.")
-    ]
+    name: Annotated[str, Field(description=("The name of the property."))]
 
 
-class SOFT5Entity(BaseModel):
-    """A SOFT5 Entity returned from this service."""
+class SOFT5Entity(SOFTEntity):
+    """A SOFT5 Entity."""
 
-    name: Annotated[str | None, Field(description="The name of the entity.")] = None
-    version: Annotated[
-        str | None, Field(description="The version of the entity.")
-    ] = None
-    namespace: Annotated[
-        AnyHttpUrl | None, Field(description="The namespace of the entity.")
-    ] = None
-    uri: Annotated[
-        AnyHttpUrl | None,
-        Field(
-            description=(
-                "The universal identifier for the entity. This MUST start with the base"
-                " URL."
-            ),
-        ),
-    ] = None
-    meta: Annotated[
-        AnyHttpUrl,
-        Field(
-            description=(
-                "URI for the metadata entity. For all entities at onto-ns.com, the "
-                "EntitySchema v0.3 is used."
-            ),
-        ),
-    ] = AnyHttpUrl("http://onto-ns.com/meta/0.3/EntitySchema")
-    description: Annotated[str, Field(description="Description of the entity.")] = ""
     dimensions: Annotated[
         list[SOFT5Dimension],
         Field(
@@ -107,88 +33,7 @@ class SOFT5Entity(BaseModel):
                 "A list of dimensions with name and an accompanying description."
             ),
         ),
-    ] = []
+    ] = []  # noqa: RUF012
     properties: Annotated[
         list[SOFT5Property], Field(description="A list of properties.")
     ]
-
-    @field_validator("uri", "namespace")
-    @classmethod
-    def _validate_base_url(cls, value: AnyHttpUrl) -> AnyHttpUrl:
-        """Validate `uri` starts with the current base URL for the service."""
-        if not str(value).startswith(str(CONFIG.base_url)):
-            error_message = (
-                "This service only works with DLite/SOFT entities at "
-                f"{CONFIG.base_url}.\n"
-            )
-            raise ValueError(error_message)
-        return value
-
-    @field_validator("uri", mode="after")
-    @classmethod
-    def _validate_uri(cls, value: AnyHttpUrl) -> AnyHttpUrl:
-        """Validate `uri` is consistent with `name`, `version`, and `namespace`."""
-        if URI_REGEX.match(str(value)) is None:
-            error_message = (
-                "The 'uri' is not a valid SOFT7 entity URI. It must be of the form "
-                f"{str(CONFIG.base_url).rstrip('/')}/{{version}}/{{name}}.\n"
-            )
-            raise ValueError(error_message)
-        return value
-
-    @field_validator("meta")
-    @classmethod
-    def _only_support_onto_ns(cls, value: AnyHttpUrl) -> AnyHttpUrl:
-        """Validate `meta` only refers to onto-ns.com EntitySchema v0.3."""
-        if str(value) != "http://onto-ns.com/meta/0.3/EntitySchema":
-            error_message = (
-                "This service only works with DLite/SOFT entities using EntitySchema "
-                "v0.3 at onto-ns.com as the metadata entity.\n"
-            )
-            raise ValueError(error_message)
-        return value
-
-    @model_validator(mode="before")
-    @classmethod
-    def _check_cross_dependent_fields(cls, data: Any) -> Any:
-        """Check that `name`, `version`, and `namespace` are all set or all unset."""
-        if (
-            isinstance(data, dict)
-            and any(data.get(_) is None for _ in ("name", "version", "namespace"))
-            and not all(data.get(_) is None for _ in ("name", "version", "namespace"))
-        ):
-            error_message = (
-                "Either all of `name`, `version`, and `namespace` must be set "
-                "or all must be unset.\n"
-            )
-            raise ValueError(error_message)
-
-        if (
-            isinstance(data, dict)
-            and any(data.get(_) is None for _ in ("name", "version", "namespace"))
-            and data.get("uri") is None
-        ):
-            error_message = (
-                "Either `name`, `version`, and `namespace` or `uri` must be set.\n"
-            )
-            raise ValueError(error_message)
-
-        if (
-            isinstance(data, dict)
-            and all(data.get(_) is not None for _ in ("name", "version", "namespace"))
-            and data.get("uri") is not None
-            and data["uri"] != f"{data['namespace']}/{data['version']}/{data['name']}"
-        ):
-            # Ensure that `uri` is consistent with `name`, `version`, and `namespace`.
-            diff = "\n  ".join(
-                difflib.ndiff(
-                    [data["uri"]],
-                    [f"{data['namespace']}/{data['version']}/{data['name']}"],
-                )
-            )
-            error_message = (
-                "The `uri` is not consistent with `name`, `version`, and "
-                f"`namespace`:\n\n  {diff}\n\n"
-            )
-            raise ValueError(error_message)
-        return data

--- a/dlite_entities_service/models/soft7.py
+++ b/dlite_entities_service/models/soft7.py
@@ -1,103 +1,24 @@
-"""SOFT7 models."""
+"""SOFT7 model."""
 from __future__ import annotations
 
-import difflib
-import re
-from typing import Annotated, Any
+from typing import Annotated
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
-from pydantic.networks import AnyHttpUrl
+from pydantic import Field
 
-from dlite_entities_service.service.config import CONFIG
-
-URI_REGEX = re.compile(
-    r"^(?P<namespace>https?://.+)/(?P<version>\d(?:\.\d+){0,2})/(?P<name>[^/#?]+)$"
-)
-"""Regular expression to parse a SOFT entity URI."""
+from dlite_entities_service.models.soft import SOFTEntity, SOFTProperty
 
 
-class SOFT7Property(BaseModel):
+class SOFT7Property(SOFTProperty):
     """The defining metadata for a SOFT7 Entity's property."""
 
-    name: Annotated[
-        str | None,
-        Field(
-            description=(
-                "The name of the property. This is not necessary if the SOFT7 approach "
-                "to entities are taken."
-            ),
-        ),
-    ] = None
-    type_: Annotated[
-        str,
-        Field(
-            alias="type",
-            description="The type of the described property, e.g., an integer.",
-        ),
-    ]
-    ref: Annotated[
-        AnyHttpUrl | None,
-        Field(
-            validation_alias=AliasChoices("$ref", "ref"),
-            serialization_alias="$ref",
-            description=(
-                "Formally a part of type. `$ref` is used together with the `ref` type, "
-                "which is a special datatype for referring to other instances."
-            ),
-        ),
-    ] = None
-    shape: Annotated[
-        list[str] | None,
-        Field(
-            description=(
-                "The dimension of multi-dimensional properties. This is a list of "
-                "dimension expressions referring to the dimensions defined above. For "
-                "instance, if an entity have dimensions with names `H`, `K`, and `L` "
-                "and a property with shape `['K', 'H+1']`, the property of an instance "
-                "of this entity with dimension values `H=2`, `K=2`, `L=6` will have "
-                "shape `[2, 3]`. Note, this was called `dims` in SOFT5."
-            ),
-        ),
-    ] = None
-    unit: Annotated[str | None, Field(description="The unit of the property.")] = None
-    description: Annotated[
-        str, Field(description="A human-readable description of the property.")
-    ]
 
+class SOFT7Entity(SOFTEntity):
+    """A SOFT7 Entity."""
 
-class SOFT7Entity(BaseModel):
-    """A SOFT7 Entity returned from this service."""
-
-    name: Annotated[str | None, Field(description="The name of the entity.")] = None
-    version: Annotated[
-        str | None, Field(description="The version of the entity.")
-    ] = None
-    namespace: Annotated[
-        AnyHttpUrl | None, Field(description="The namespace of the entity.")
-    ] = None
-    uri: Annotated[
-        AnyHttpUrl | None,
-        Field(
-            description=(
-                "The universal identifier for the entity. This MUST start with the "
-                "base URL."
-            ),
-        ),
-    ] = None
-    meta: Annotated[
-        AnyHttpUrl,
-        Field(
-            description=(
-                "URI for the metadata entity. For all entities at onto-ns.com, the "
-                "EntitySchema v0.3 is used."
-            ),
-        ),
-    ] = AnyHttpUrl("http://onto-ns.com/meta/0.3/EntitySchema")
-    description: Annotated[str, Field(description="Description of the entity.")] = ""
     dimensions: Annotated[
         dict[str, str],
         Field(description="A dict of dimensions with an accompanying description."),
-    ] = {}
+    ] = {}  # noqa: RUF012
     properties: Annotated[
         dict[str, SOFT7Property],
         Field(
@@ -107,85 +28,3 @@ class SOFT7Entity(BaseModel):
             ),
         ),
     ]
-
-    @field_validator("uri", "namespace", mode="after")
-    @classmethod
-    def _validate_base_url(cls, value: AnyHttpUrl) -> AnyHttpUrl:
-        """Validate `uri` and `namespace` starts with the current base URL for the
-        service."""
-        if not str(value).startswith(str(CONFIG.base_url)):
-            error_message = (
-                "This service only works with DLite/SOFT entities at "
-                f"{CONFIG.base_url}.\n"
-            )
-            raise ValueError(error_message)
-        return value
-
-    @field_validator("uri", mode="after")
-    @classmethod
-    def _validate_uri(cls, value: AnyHttpUrl) -> AnyHttpUrl:
-        """Validate `uri` is consistent with `name`, `version`, and `namespace`."""
-        if URI_REGEX.match(str(value)) is None:
-            error_message = (
-                "The 'uri' is not a valid SOFT7 entity URI. It must be of the form "
-                f"{str(CONFIG.base_url).rstrip('/')}/{{version}}/{{name}}.\n"
-            )
-            raise ValueError(error_message)
-        return value
-
-    @field_validator("meta", mode="after")
-    @classmethod
-    def _only_support_onto_ns(cls, value: AnyHttpUrl) -> AnyHttpUrl:
-        """Validate `meta` only refers to onto-ns.com EntitySchema v0.3."""
-        if str(value) != "http://onto-ns.com/meta/0.3/EntitySchema":
-            error_message = (
-                "This service only works with DLite/SOFT entities using EntitySchema "
-                "v0.3 at onto-ns.com as the metadata entity.\n"
-            )
-            raise ValueError(error_message)
-        return value
-
-    @model_validator(mode="before")
-    @classmethod
-    def _check_cross_dependent_fields(cls, data: Any) -> Any:
-        """Check that `name`, `version`, and `namespace` are all set or all unset."""
-        if (
-            isinstance(data, dict)
-            and any(data.get(_) is None for _ in ("name", "version", "namespace"))
-            and not all(data.get(_) is None for _ in ("name", "version", "namespace"))
-        ):
-            error_message = (
-                "Either all of `name`, `version`, and `namespace` must be set "
-                "or all must be unset.\n"
-            )
-            raise ValueError(error_message)
-
-        if (
-            isinstance(data, dict)
-            and any(data.get(_) is None for _ in ("name", "version", "namespace"))
-            and data.get("uri") is None
-        ):
-            error_message = (
-                "Either `name`, `version`, and `namespace` or `uri` must be set.\n"
-            )
-            raise ValueError(error_message)
-
-        if (
-            isinstance(data, dict)
-            and all(data.get(_) is not None for _ in ("name", "version", "namespace"))
-            and data.get("uri") is not None
-            and data["uri"] != f"{data['namespace']}/{data['version']}/{data['name']}"
-        ):
-            # Ensure that `uri` is consistent with `name`, `version`, and `namespace`.
-            diff = "\n  ".join(
-                difflib.ndiff(
-                    [data["uri"]],
-                    [f"{data['namespace']}/{data['version']}/{data['name']}"],
-                )
-            )
-            error_message = (
-                "The `uri` is not consistent with `name`, `version`, and "
-                f"`namespace`:\n\n  {diff}\n\n"
-            )
-            raise ValueError(error_message)
-        return data

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -61,8 +61,8 @@ def test_upload_filepath_invalid(
     )
     assert result.exit_code == 1, result.stdout
     assert "Person.json is not a valid SOFT entity:" in result.stderr.replace("\n", "")
-    assert "validation error for SOFT7Entity" in result.stderr.replace("\n", "")
-    assert "validation errors for SOFT5Entity" in result.stderr.replace("\n", "")
+    assert "validation error for DLiteSOFT7Entity" in result.stderr.replace("\n", "")
+    assert "validation errors for DLiteSOFT5Entity" in result.stderr.replace("\n", "")
     assert not result.stdout
     if fail_fast:
         assert (
@@ -215,13 +215,13 @@ def test_upload_directory_invalid_entities(
     assert result.exit_code == 1, result.stderr
     assert (
         re.search(
-            r"validation errors? for SOFT7Entity", result.stderr.replace("\n", "")
+            r"validation errors? for DLiteSOFT7Entity", result.stderr.replace("\n", "")
         )
         is not None
     )
     assert (
         re.search(
-            r"validation errors? for SOFT5Entity", result.stderr.replace("\n", "")
+            r"validation errors? for DLiteSOFT5Entity", result.stderr.replace("\n", "")
         )
         is not None
     )

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -25,7 +25,7 @@ def test_get_entity(
     name: str,
     client: TestClient,
 ) -> None:
-    """Test the route to retrieve a DLite/SOFT entity."""
+    """Test the route to retrieve an entity."""
     from fastapi import status
 
     with client as client:
@@ -35,6 +35,12 @@ def test_get_entity(
         response.is_success
     ), f"Response: {response.json()}. Request: {response.request}"
     assert response.status_code == status.HTTP_200_OK, response.json()
+
+    # Convert SOFT5 properties' 'dims' to 'shape'
+    for entity_property in entity["properties"]:
+        if "dims" in entity_property:
+            entity_property["shape"] = entity_property.pop("dims")
+
     assert (resolved_entity := response.json()) == entity, resolved_entity
 
 
@@ -58,6 +64,11 @@ def test_get_entity_instance(
 
     with client as client:
         response = client.get(f"/{version}/{name}", timeout=5)
+
+    # Convert SOFT5 properties' 'dims' to 'shape'
+    for entity_property in entity["properties"]:
+        if "dims" in entity_property:
+            entity_property["shape"] = entity_property.pop("dims")
 
     assert (resolve_entity := response.json()) == entity, resolve_entity
 


### PR DESCRIPTION
Closes #64 

Create a "minimum set" of fields for the versioned SOFT models and then create the DLite implementations of these separately.

This should be implemented in conjunction with #70